### PR TITLE
fixed legibility/color of Rename List's EditText

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -27,18 +27,9 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="java.util" alias="false" withSubpackages="false" />
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-          <package name="io.ktor" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
+          <package name="java.util" withSubpackages="false" static="false" />
+          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
+          <package name="io.ktor" withSubpackages="true" static="false" />
         </value>
       </option>
     </JetCodeStyleSettings>

--- a/app/src/main/res/layout/popup_rename_list.xml
+++ b/app/src/main/res/layout/popup_rename_list.xml
@@ -1,27 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout   xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:visibility="visible"
-    android:background="#FF5722"
-    android:padding="10dp"
-    android:orientation="vertical">
+    android:background="@color/transparent"
+    android:backgroundTint="#0BA5B6"
+    android:orientation="vertical"
+    android:padding="15dp"
+    android:visibility="visible">
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:paddingBottom="@dimen/vert_small"
         android:text="@string/rename_list_new_title"
-        android:textSize="@dimen/text_medium"
-        android:textColor="#263238"
-        android:paddingBottom="@dimen/vert_small"/>
+        android:textColor="#23C3D5"
+        android:textSize="@dimen/text_medium" />
 
     <EditText
         android:id="@+id/popup_rename_list_edittext"
+        android:hint="rename your list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="#43A047"
+        android:background="@color/transparent"
+        android:backgroundTint="#D50000"
         android:shadowColor="#FFFFFF"
         android:textColor="#F5F5F5"
-        android:visibility="visible" />
+        android:visibility="visible"
+        android:theme="@style/rename_list_edittext"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/popup_rename_list.xml
+++ b/app/src/main/res/layout/popup_rename_list.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:visibility="visible"
-    android:background="@color/transparent"
+    android:background="#FF5722"
     android:padding="10dp"
     android:orientation="vertical">
 
@@ -12,13 +12,16 @@
         android:layout_height="wrap_content"
         android:text="@string/rename_list_new_title"
         android:textSize="@dimen/text_medium"
-        android:textColor="@color/accentPrimary"
+        android:textColor="#263238"
         android:paddingBottom="@dimen/vert_small"/>
 
     <EditText
         android:id="@+id/popup_rename_list_edittext"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:visibility="visible"/>
+        android:background="#43A047"
+        android:shadowColor="#FFFFFF"
+        android:textColor="#F5F5F5"
+        android:visibility="visible" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/widget.xml
+++ b/app/src/main/res/layout/widget.xml
@@ -25,6 +25,9 @@
         android:layout_height="wrap_content"
         android:layout_below="@+id/widget_list_name"
         android:layout_alignParentStart="true"
-        android:layout_alignParentEnd="true"/>
+        android:layout_alignParentEnd="true"
+        android:layout_marginStart="11dp"
+        android:layout_marginTop="1dp"
+        android:layout_marginEnd="16dp" />
 
 </RelativeLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,6 +5,10 @@
         <item name="android:statusBarColor">@color/transparent</item>
 
     </style>
+    <style name="rename_list_edittext" parent="Theme.AppCompat.NoActionBar">
+        <item name="colorControlNormal" >@color/redBright</item>
+        <item name="colorControlActivated">#23C3D5</item>
+    </style>
 
     <style name="listActivityTheme" parent="Theme.AppCompat.NoActionBar">
         <item name="android:statusBarColor">@color/transparent</item>


### PR DESCRIPTION
The color of the text in EditText of Rename List popup was black with a grey background which was decreasing readability.
Tried to solve this issue!
![Screenshot (326)](https://user-images.githubusercontent.com/63780355/96045151-2fccdf80-0e8f-11eb-867c-37fc3ae8d091.png)
