### PR TITLE
Size of delete text passed from dimen 

### DIFF
--- a/app/src/main/java/com/example/todo/HomePage.java
+++ b/app/src/main/java/com/example/todo/HomePage.java
@@ -119,7 +119,7 @@ public class HomePage extends AppCompatActivity {
         SwipeToDeleteCallback swipeToDeleteCallback = new SwipeToDeleteCallback(getApplicationContext(),dynamicRecycler,200) {
             @Override
             public void instantiateMyButton(final RecyclerView.ViewHolder viewHolder, List<SwipeToDeleteCallback.MyButton> buffer) {
-                buffer.add(new MyButton(getApplicationContext(),"",30,R.drawable.icon_delete, Color.RED,
+                buffer.add(new MyButton(getApplicationContext(),"Delete",getApplicationContext().getResources().getDimensionPixelSize(R.dimen.text_small),0, Color.RED,
                         new onSwipeDeleteButtonListener(){
                             @Override
                             public void onClick(int pos) {


### PR DESCRIPTION
The pr deals with the sub-issue 2 of avoiding hard coded values as text size. The size of the delete text is taken from the dimen folder, converted to px and passed to the constructor.
![delete-Text](https://user-images.githubusercontent.com/53570696/96585569-6b3b3400-12fd-11eb-9cb5-96a504b47b46.jpeg)
